### PR TITLE
disable enableUnitTestBinaryResources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-android.enableUnitTestBinaryResources=true
+# android.enableUnitTestBinaryResources=true
 android.builder.sdkDownload=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-# android.enableUnitTestBinaryResources=true
 android.builder.sdkDownload=true


### PR DESCRIPTION
Disables the deprecated `enableUnitTestBinaryResources` flag. This prevents building the android app after gradle update:
https://github.com/mauron85/react-native-background-geolocation/issues/503