### PR TITLE
Use mipmap icons

### DIFF
--- a/src/main/java/com/marianhello/bgloc/ResourceResolver.java
+++ b/src/main/java/com/marianhello/bgloc/ResourceResolver.java
@@ -33,6 +33,10 @@ public class ResourceResolver {
         return getAppResource(resourceName, "drawable");
     }
 
+    public Integer getMipMap(String resourceName) {
+        return getAppResource(resourceName, "mipmap");
+    }
+
     public String getString(String name) {
         return getApplicationContext().getString(getAppResource(name, "string"));
     }

--- a/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
+++ b/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
@@ -57,12 +57,12 @@ public class NotificationHelper {
             builder.setContentTitle(title);
             builder.setContentText(text);
             if (smallIcon != null && !smallIcon.isEmpty()) {
-                builder.setSmallIcon(mResolver.getDrawable(smallIcon));
+                builder.setSmallIcon(mResolver.getMipMap(smallIcon));
             } else {
                 builder.setSmallIcon(android.R.drawable.ic_menu_mylocation);
             }
             if (largeIcon != null && !largeIcon.isEmpty()) {
-                builder.setLargeIcon(BitmapFactory.decodeResource(appContext.getResources(), mResolver.getDrawable(largeIcon)));
+                builder.setLargeIcon(BitmapFactory.decodeResource(appContext.getResources(), mResolver.getMipMap(largeIcon)));
             }
             if (color != null && !color.isEmpty()) {
                 builder.setColor(this.parseNotificationIconColor(color));


### PR DESCRIPTION
For parity with `react-native-push-notification` library use notification icons from `mipmap` folder instead of `drawable`.
https://github.com/zo0r/react-native-push-notification/blob/master/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java#L357

We are not using notification icons yet, this change won't have any impact in the app